### PR TITLE
Added option to provide config file instead of answering prompt questions

### DIFF
--- a/README
+++ b/README
@@ -16,6 +16,23 @@ This installer guides you through the configuration process and generates a
 init.d script if you are on a unix system or creates the service if you are
 on a windows box.
 
+You can optionally provide a configuration file to the trinidad_init_service
+command.  An example configuration file might look like this:
+
+    app_path: "/home/myuser/app"
+    trinidad_options: "-e production"
+    jruby_home: "/opt/jruby"
+    ruby_compat_version: RUBY1_8
+    trinidad_name: Trinidad
+    jsvc_path: "/usr/bin/jsvc"
+    java_home: "/opt/java"
+    output_path: "/etc/init.d"
+    pid_file: "/tmp/trinidad.pid"
+    log_file: "/tmp/trinidad.log"
+
+If any of these options are not provided, then the installer will prompt you
+for them.
+
 Unix
 ====
 

--- a/bin/trinidad_init_service
+++ b/bin/trinidad_init_service
@@ -1,3 +1,12 @@
-require 'trinidad_init_services/configuration'
+#!/usr/bin/env jruby
 
-Trinidad::InitServices::Configuration.new.configure
+require 'trinidad_init_services/configuration'
+require 'yaml'
+
+if ARGV.size > 0
+  config_file = File.read(ARGV[0])
+  config = YAML.load(config_file)
+  Trinidad::InitServices::Configuration.new.configure(config)
+else
+  Trinidad::InitServices::Configuration.new.configure
+end

--- a/lib/trinidad_init_services/configuration.rb
+++ b/lib/trinidad_init_services/configuration.rb
@@ -19,11 +19,11 @@ module Trinidad
         @classpath << File.join(@jruby_home, 'lib', 'jruby.jar')
       end
 
-      def collect_windows_opts(options_ask)
+      def collect_windows_opts(options_ask, defaults)
         options_ask << '(separated by `;`)'
         name_ask = 'Service name? {Alphanumeric and spaces only}'
         name_default = 'Trinidad'
-        @trinidad_name = ask(name_ask, name_default)
+        @trinidad_name = defaults["trinidad_name"] || ask(name_ask, name_default)
       end
 
       def configure_jruby_opts
@@ -36,29 +36,29 @@ module Trinidad
         opts
       end
 
-      def configure
-        @app_path = ask_path('Application path?')
+      def configure(defaults={})
+        @app_path = defaults["app_path"] || ask_path('Application path?')
         @trinidad_options = ["-d #{@app_path}"]
         options_ask = 'Trinidad options?'
         options_default = '-e production'
-        collect_windows_opts(options_ask) if windows?
+        collect_windows_opts(options_ask, defaults) if windows?
 
-        @trinidad_options << ask(options_ask, options_default)
-        @jruby_home = ask_path('JRuby home?', default_jruby_home)
-        @ruby_compat_version = ask('Ruby 1.8.x or 1.9.x compatibility?', default_ruby_compat_version)
+        @trinidad_options << (defaults["trinidad_options"] || ask(options_ask, options_default))
+        @jruby_home = defaults["jruby_home"] || ask_path('JRuby home?', default_jruby_home)
+        @ruby_compat_version = defaults["ruby_compat_version"] || ask('Ruby 1.8.x or 1.9.x compatibility?', default_ruby_compat_version)
         @jruby_opts = configure_jruby_opts
         initialize_paths
 
-        windows? ? configure_windows_service : configure_unix_daemon
+        windows? ? configure_windows_service : configure_unix_daemon(defaults)
         puts 'Done.'
       end
 
-      def configure_unix_daemon
-        @jsvc = jsvc_path
-        @java_home = ask_path('Java home?', default_java_home)
-        @output_path = ask_path('init.d output path?', '/etc/init.d')
-        @pid_file = ask_path('pid file?', '/var/run/trinidad/trinidad.pid')
-        @log_file = ask_path('log file?', '/var/log/trinidad/trinidad.log')
+      def configure_unix_daemon(defaults)
+        @jsvc = defaults["jsvc_path"] || jsvc_path
+        @java_home = defaults["java_home"] || ask_path('Java home?', default_java_home)
+        @output_path = defaults["output_path"] || ask_path('init.d output path?', '/etc/init.d')
+        @pid_file = defaults["pid_file"] || ask_path('pid file?', '/var/run/trinidad/trinidad.pid')
+        @log_file = defaults["log_file"] || ask_path('log file?', '/var/log/trinidad/trinidad.log')
 
         daemon = ERB.new(
           File.read(

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,19 @@
+begin
+  require 'rspec'
+rescue LoadError
+  require 'rubygems'
+  gem 'rspec'
+  require 'rspec'
+end
+
+$:.unshift(File.dirname(__FILE__) + '/../lib')
+
+require 'trinidad_init_services/configuration'
+
+require 'java'
+require 'mocha'
+require 'fileutils'
+
+RSpec.configure do |config|
+  config.mock_with :mocha
+end

--- a/spec/trinidad_init_services/configuration_spec.rb
+++ b/spec/trinidad_init_services/configuration_spec.rb
@@ -1,0 +1,61 @@
+require File.dirname(__FILE__) + '/../spec_helper'
+require 'yaml'
+
+describe Trinidad::InitServices::Configuration do
+
+  before do
+    Dir.mkdir(tmp_dir) unless File.exist?(tmp_dir)
+    Dir.mkdir(init_dir) 
+    
+    config = <<YAML
+app_path: "tmp/app"
+trinidad_options: "-e production"
+jruby_home: "tmp/jruby"
+ruby_compat_version: RUBY1_8
+trinidad_name: Trinidad
+jsvc_path: "tmp/jsvc"
+java_home: "tmp/java"
+output_path: "tmp/etc_init.d"
+pid_file: "tmp/trinidad.pid"
+log_file: "tmp/trinidad.log"
+YAML
+
+    defaults = YAML::load(config)
+
+    subject.configure(defaults)
+  end
+
+  after do
+    File.delete(init_file)
+    Dir.rmdir(init_dir)
+    Dir.rmdir(tmp_dir)
+  end
+
+	it "is creates the init.d file" do
+		File.exist?(init_file).should be_true
+
+    init_file_content = File.read(init_file)
+
+    init_file_content.match(/JSVC=tmp\/jsvc/).should be_true
+    init_file_content.match(/JAVA_HOME=tmp\/java/).should be_true
+    init_file_content.match(/JRUBY_HOME=tmp\/jruby/).should be_true
+    init_file_content.match(/APP_PATH=tmp\/app/).should be_true
+    init_file_content.match(/TRINIDAD_OPTS="-d tmp\/app -e production"/).should be_true
+  end
+
+  def init_file
+    "#{init_dir}/trinidad"
+  end
+
+  def init_dir
+    "#{tmp_dir}/etc_init.d/"
+  end
+
+  def tmp_dir
+    "#{root_dir}/tmp"
+  end
+
+  def root_dir
+    File.dirname(__FILE__) + "/../../"
+  end
+end


### PR DESCRIPTION
I added an option to the trinidad_init_server script that allows it to accept a configuration file.  If this config file contains the answers to the "ask" questions in the Configuration class, then it won't ask the user for them.

This makes automated set up of new environments easier.

I added specs.

Let me know if you would like this to be modified at all.   
