### PR TITLE
Fix issue on with -errfile &1 being misinterpreted.

### DIFF
--- a/init.d/trinidad.erb
+++ b/init.d/trinidad.erb
@@ -55,7 +55,7 @@ JSVC_ARGS="-home $JAVA_HOME \
   -procname jsvc-$SCRIPT_NAME \
   -jvm server
   -outfile $LOG_FILE \
-  -errfile &1"
+  -errfile '&1'"
 
 #
 # Stop/Start


### PR DESCRIPTION
This commit fixes a weird issue i've been having where the `&1` JSVC option would appear to be interpreted as:

Background the process `&` and run `1`

And would return the following ouput:

```
[1] 992
Invalid Error File specified
Cannot parse command line arguments
1: command not found
```

This issue is present on Ubuntu 10.04 LTS and bash version 4.1.5(1).
