### PR TITLE
a better jsvc -procname

### DIFF
--- a/init.d/trinidad.erb
+++ b/init.d/trinidad.erb
@@ -5,9 +5,7 @@
 # Contains common parameters and start/stop
 
 # Things you'll need to set on a per script/daemon basis:
-# SCRIPT_NAME - Path to the ruby script which creates a Daemon
-# object for jsvc to control
-# APP_NAME - Name of your application
+# APP_NAME - name of your application (defaults to "trinidad")
 #
 # Things you can set:
 # PROG_OPTS - Arguments to send to the program. A few defaults are appended to this.
@@ -46,13 +44,14 @@ JAVA_PROPS="$JAVA_PROPS -Djruby.memory.max=500m \
   $JRUBY_OPTS"
 
 JAVA_OPTS="-Xmx500m -Xss1024k -Xbootclasspath/a:$JRUBY_HOME/lib/jruby.jar"
+PROC_NAME=${SCRIPT_NAME:-${APP_NAME:-"trinidad"}}
 
 JSVC_ARGS="-home $JAVA_HOME \
   $JSVC_ARGS_EXTRA \
   -wait 20 \
   -pidfile $PIDFILE \
   -user $USER \
-  -procname jsvc-$SCRIPT_NAME \
+  -procname jsvc-$PROC_NAME \
   -jvm server
   -outfile $LOG_FILE \
   -errfile '&1'"
@@ -72,7 +71,7 @@ case "$1" in
           echo "Pidfile already exists, not starting."
           exit 1
       else
-          echo "Starting $SCRIPT_NAME daemon..."
+          echo "Starting $PROC_NAME daemon..."
           $START_COMMAND
           EXIT_CODE=$?
           if [ "$EXIT_CODE" != 0 ]; then
@@ -82,7 +81,7 @@ case "$1" in
       ;;
     stop)
       if [ -e "$PIDFILE" ]; then
-          echo "Stopping $SCRIPT_NAME daemon..."
+          echo "Stopping $PROC_NAME daemon..."
           $STOP_COMMAND
       else
           echo "No pid file, not stopping."
@@ -91,11 +90,11 @@ case "$1" in
       ;;
     restart)
       if [ -e "$PIDFILE" ]; then
-          echo "Stopping $SCRIPT_NAME daemon..."
+          echo "Stopping $PROC_NAME daemon..."
           $STOP_COMMAND
       fi
       if [ -e "$PIDFILE" ]; then
-          echo "Pidfile still present, $SCRIPT_NAME hasn't stopped"
+          echo "Pidfile still present, $PROC_NAME hasn't stopped"
           exit 1
       else
           $START_COMMAND


### PR DESCRIPTION
I noticed the #7's procname ends up as "jsvc-" just like mine, I thought we can do better ...
(defaults to "trinidad" if $SCRIPT_NAME or $APP_NAME is not defined)

Also $SCRIPT_NAME does not seems to do what it was "documented" in the top comment.
Or maybe I just missed something bash-y (thus I rather did not commit this straight in) ?
