### PR TITLE
Well this is embarressing..

### DIFF
--- a/init.d/trinidad.erb
+++ b/init.d/trinidad.erb
@@ -54,7 +54,7 @@ JSVC_ARGS="-home $JAVA_HOME \
   -procname jsvc-$PROC_NAME \
   -jvm server
   -outfile $LOG_FILE \
-  -errfile '&1'"
+  -errfile &1"
 
 #
 # Stop/Start


### PR DESCRIPTION
Hi guys it turns out that my "fix" last night actually introduces a bug too!
It logs to a file called `'&1'` in your webapps dir instead or failing loudly.

One solution may be to specify a log file manually instead of stdout, but i'll leave that up to you guys.

I am so sorry! :'(
You may want to roll another new version of the gem.

Go easy on me.. that was my first pull request!
