### PR TITLE
Fix issue where $USER is undefined in init.

### DIFF
--- a/init.d/trinidad.erb
+++ b/init.d/trinidad.erb
@@ -16,6 +16,9 @@ JRUBY_HOME=<%= @jruby_home %>
 APP_PATH=<%= @app_path %>
 RUBY_SCRIPT=<%= @trinidad_daemon_path %>
 
+# $USER should be already defined, but there are weird edge cases where it is not.
+: ${USER:=`whoami`}
+
 # Add here the options that Trinidad needs to run your application,
 # but DO NOT delete the -d option, i.e -e production
 TRINIDAD_OPTS="<%= @trinidad_options.join(" ") %>"


### PR DESCRIPTION
Hi, me again :P

This commit fixes an issue we've been having where the service would not start on boot correctly because the $USER variable was undefined.

As $USER gets interpolated in the command it'd run (notice the -user flag):

```
/usr/bin/jsvc -home /usr/lib/jvm/java-6-openjdk/jre      -wait 20   -pidfile /var/run/trinidad.pid   -user    -procname jsvc-   -jvm server  .........
```

This only shows up for us when the script is getting run by init on boot.

Hope this helps :)
