### PR TITLE
avoid jsvc -user and use sudo instead if $RUN_USER provided

### DIFF
--- a/init.d/trinidad.erb
+++ b/init.d/trinidad.erb
@@ -15,6 +15,7 @@ JAVA_HOME=<%= @java_home %>
 JRUBY_HOME=<%= @jruby_home %>
 APP_PATH=<%= @app_path %>
 RUBY_SCRIPT=<%= @trinidad_daemon_path %>
+RUN_USER="<%= @run_user %>"
 
 # Add here the options that Trinidad needs to run your application,
 # but DO NOT delete the -d option, i.e -e production
@@ -50,15 +51,18 @@ JSVC_ARGS="-home $JAVA_HOME \
   $JSVC_ARGS_EXTRA \
   -wait 20 \
   -pidfile $PIDFILE \
-  -user $USER \
   -procname jsvc-$PROC_NAME \
   -jvm server
   -outfile $LOG_FILE \
   -errfile &1"
-
+  
 #
 # Stop/Start
 #
+
+if [[ -n $RUN_USER && $EUID -eq 0 ]]; then
+  JSVC="sudo -u $RUN_USER $JSVC"
+fi
 
 STOP_COMMAND="$JSVC $JSVC_ARGS -stop $MAIN_CLASS"
 START_COMMAND="$JSVC $JSVC_ARGS -cp $CLASSPATH $JAVA_PROPS $JAVA_OPTS $MAIN_CLASS $RUBY_SCRIPT $TRINIDAD_OPTS"

--- a/lib/trinidad_init_services/configuration.rb
+++ b/lib/trinidad_init_services/configuration.rb
@@ -59,7 +59,13 @@ module Trinidad
         @output_path = defaults["output_path"] || ask_path('init.d output path?', '/etc/init.d')
         @pid_file = defaults["pid_file"] || ask_path('pid file?', '/var/run/trinidad/trinidad.pid')
         @log_file = defaults["log_file"] || ask_path('log file?', '/var/log/trinidad/trinidad.log')
-
+        @run_user = defaults["run_user"] || ask_path('run daemon as user?', '')
+        
+        @run_user.strip!
+        if @run_user != '' && `id -u #{@run_user}` == ''
+          raise ArgumentError, "'#{@run_user}' does not exist"
+        end
+        
         daemon = ERB.new(
           File.read(
             File.expand_path('../../init.d/trinidad.erb', File.dirname(__FILE__))

--- a/lib/trinidad_init_services/configuration.rb
+++ b/lib/trinidad_init_services/configuration.rb
@@ -59,12 +59,14 @@ module Trinidad
         @output_path = defaults["output_path"] || ask_path('init.d output path?', '/etc/init.d')
         @pid_file = defaults["pid_file"] || ask_path('pid file?', '/var/run/trinidad/trinidad.pid')
         @log_file = defaults["log_file"] || ask_path('log file?', '/var/log/trinidad/trinidad.log')
-        @run_user = defaults["run_user"] || ask_path('run daemon as user?', '')
+        @run_user = defaults["run_user"] || ask('run daemon as user (enter a non-root username or leave blank)?', '')
         
-        @run_user.strip!
         if @run_user != '' && `id -u #{@run_user}` == ''
-          raise ArgumentError, "'#{@run_user}' does not exist"
+          raise ArgumentError, "user '#{@run_user}' does not exist (leave blank if you're planning to `useradd' later)"
         end
+        
+        make_path_dir(@pid_file, "could not create dir for '#{@pid_file}', make sure dir exists before running daemon")
+        make_path_dir(@log_file, "could not create dir for '#{@log_file}', make sure dir exists before running daemon")
         
         daemon = ERB.new(
           File.read(
@@ -73,12 +75,9 @@ module Trinidad
         ).result(binding)
 
         puts "Moving trinidad to #{@output_path}"
-        tmp_file = "#{@output_path}/trinidad"
-        File.open(tmp_file, 'w') do |file|
-          file.write(daemon)
-        end
-
-        FileUtils.chmod(0744, tmp_file)
+        trinidad_file = File.join(@output_path, "trinidad")
+        File.open(trinidad_file, 'w') { |file| file.write(daemon) }
+        FileUtils.chmod(@run_user == '' ? 0744 : 0755, trinidad_file)
       end
 
       def configure_windows_service
@@ -141,6 +140,17 @@ module Trinidad
         File.join(@jars_path, prunsrv)
       end
 
+      def make_path_dir(path, error = nil)
+        dir = File.dirname(path)
+        return if File.exist?(dir)
+        begin
+          FileUtils.mkdir_p dir, :mode => 0775
+        rescue Errno::EACCES => e
+          raise unless error
+          puts "#{error} (#{e})"
+        end
+      end
+      
       def ask_path(question, default = nil)
         File.expand_path(ask(question, default))
       end

--- a/spec/trinidad_init_services/configuration_spec.rb
+++ b/spec/trinidad_init_services/configuration_spec.rb
@@ -1,13 +1,79 @@
 require File.dirname(__FILE__) + '/../spec_helper'
 require 'yaml'
+require 'rbconfig'
 
 describe Trinidad::InitServices::Configuration do
-
-  before do
+  
+  before :each do
     Dir.mkdir(tmp_dir) unless File.exist?(tmp_dir)
-    Dir.mkdir(init_dir) 
+    Dir.mkdir(init_dir)
+  end
+
+  after :each do
+    FileUtils.rm_r init_dir
+    Dir.rmdir(tmp_dir) if Dir.entries(tmp_dir) == [ '.', '..' ]
+  end
+
+	it "creates the init.d file" do
+    subject.configure(config_defaults)
     
-    config = <<YAML
+		File.exist?(init_file).should be_true
+
+    init_file_content = File.read(init_file)
+
+    init_file_content.match(/JSVC=tmp\/jsvc/).should be_true
+    init_file_content.match(/JAVA_HOME=tmp\/java/).should be_true
+    init_file_content.match(/JRUBY_HOME=tmp\/jruby/).should be_true
+    init_file_content.match(/APP_PATH=tmp\/app/).should be_true
+    init_file_content.match(/TRINIDAD_OPTS="-d tmp\/app -e production"/).should be_true
+    
+    init_file_content.match(/RUN_USER=""/).should be_true
+  end
+
+  it "makes pid_file and log_file dirs" do
+    pids_dir = File.join(tmp_dir, "pids")
+    logs_dir = File.join(tmp_dir, "logs")
+    begin
+      subject.configure(
+        config_defaults.merge 'pid_file' => "tmp/pids/trinidad.pid", 'log_file' => "tmp/logs/trinidad.log"
+      )
+      
+      File.exist?(pids_dir).should be_true
+      File.directory?(pids_dir).should be_true
+      Dir.entries(pids_dir).should == ['.', '..']
+
+      File.exist?(logs_dir).should be_true
+      File.directory?(logs_dir).should be_true
+      Dir.entries(logs_dir).should == ['.', '..']
+    ensure
+      Dir.rmdir(pids_dir) if File.exist?(pids_dir)
+      Dir.rmdir(logs_dir) if File.exist?(logs_dir)
+    end
+  end
+  
+  if RbConfig::CONFIG['host_os'] !~ /mswin|mingw/i
+
+    it "fails for non-existing run user" do
+      username = random_username
+      lambda { 
+        subject.configure(config_defaults.merge 'run_user' => username) 
+      }.should raise_error(ArgumentError)
+    end
+    
+    it "sets valid run user" do
+      username = `whoami`.chomp
+      subject.configure(config_defaults.merge 'run_user' => username)
+
+      init_file_content = File.read(init_file) rescue ''
+      init_file_content.match(/RUN_USER="#{username}"/).should be_true
+    end
+    
+  end
+  
+  private
+  
+    def config_defaults
+      YAML::load %Q{
 app_path: "tmp/app"
 trinidad_options: "-e production"
 jruby_home: "tmp/jruby"
@@ -18,44 +84,28 @@ java_home: "tmp/java"
 output_path: "tmp/etc_init.d"
 pid_file: "tmp/trinidad.pid"
 log_file: "tmp/trinidad.log"
-YAML
+run_user: ""
+}
+    end
+  
+    def init_file
+      File.join init_dir, 'trinidad'
+    end
 
-    defaults = YAML::load(config)
+    def init_dir
+      File.join tmp_dir, 'etc_init.d'
+    end
 
-    subject.configure(defaults)
-  end
+    def tmp_dir
+      File.join root_dir, 'tmp'
+    end
 
-  after do
-    File.delete(init_file)
-    Dir.rmdir(init_dir)
-    Dir.rmdir(tmp_dir)
-  end
-
-	it "is creates the init.d file" do
-		File.exist?(init_file).should be_true
-
-    init_file_content = File.read(init_file)
-
-    init_file_content.match(/JSVC=tmp\/jsvc/).should be_true
-    init_file_content.match(/JAVA_HOME=tmp\/java/).should be_true
-    init_file_content.match(/JRUBY_HOME=tmp\/jruby/).should be_true
-    init_file_content.match(/APP_PATH=tmp\/app/).should be_true
-    init_file_content.match(/TRINIDAD_OPTS="-d tmp\/app -e production"/).should be_true
-  end
-
-  def init_file
-    "#{init_dir}/trinidad"
-  end
-
-  def init_dir
-    "#{tmp_dir}/etc_init.d/"
-  end
-
-  def tmp_dir
-    "#{root_dir}/tmp"
-  end
-
-  def root_dir
-    File.dirname(__FILE__) + "/../../"
-  end
+    def root_dir
+      File.join File.dirname(__FILE__), "/../../"
+    end
+    
+    def random_username(len = 8)
+      (0...len).map{ ( 65 + rand(25) ).chr }.join.downcase
+    end
+    
 end


### PR DESCRIPTION
not sure how for others but for me and @boxofrad `jsvc -user` does not really work.
he even issued a pull to fix it #11 - got me thinking it's a bit useless to have it anyway (assuming I'm not the only one it does not work for).

now I assume the "safest" use for running **trinidad** is under an application (non-root) user and proxying with apache or whatever. the new `/etc/init.d/trinidad` now supports this case, even when it's boot-ed by _root_ (I expected this to be accomplishable with `jsvc -user`).
it's still possible to roll the "old" _root_ way.

hopefully, this does make sense to others using the daemon on linux, would appreciate a review.

I also attempt to make directories for _pid_file_ and _log_file_ paths
