### PR TITLE
return default from Configuration#ask when not in a tty, it was causing ...

### DIFF
--- a/lib/trinidad_init_services/configuration.rb
+++ b/lib/trinidad_init_services/configuration.rb
@@ -244,7 +244,7 @@ module Trinidad
       end
 
       def ask(question, default = nil)
-        return nil if not @stdin.tty?
+        return default if not @stdin.tty?
 
         question << " [#{default}]" if default && !default.empty?
 


### PR DESCRIPTION
...a MethodNotFound in ask_path for java_home.
