### PR TITLE
Add support for TRINIDAD_JAVA_MEM as an alternate environment variable to JAVA_MEM

### DIFF
--- a/init.d/trinidad.erb
+++ b/init.d/trinidad.erb
@@ -65,7 +65,10 @@ if [ -d "$JRUBY_HOME/lib/native/" ]; then
   done
 fi
 
-if [ -z "$JAVA_MEM" ] ; then
+# Allow TRINIDAD_JAVA_MEM as JAVA_MEM is interpreted differently by jruby
+if [ "$TRINIDAD_JAVA_MEM" ] ; then
+  JAVA_MEM=$TRINIDAD_JAVA_MEM
+elif [ -z "$JAVA_MEM" ] ; then
   JAVA_MEM=500m
 fi
 


### PR DESCRIPTION
This introduces the TRINIDAD_JAVA_MEM environment variable as an alternate to JAVA_MEM.  This is useful in cases where JAVA_MEM may be interpreted by jruby as init.d/trinidad interprets it differently than jruby.  

JAVA_MEM is still supported for backward compatiblity

This fixes #26
