### PR TITLE
Fixing init blank space bug.

### DIFF
--- a/init.d/trinidad.erb
+++ b/init.d/trinidad.erb
@@ -167,7 +167,7 @@ case "$1" in
     status)
       if [ "$PIDFILE" ]; then
           PID=`cat $PIDFILE`
-          OUTPUT=`ps $PID | egrep "^$PID "`
+          OUTPUT=`ps -p $PID`
           if [ ${#OUTPUT} -gt 0 ]; then
               echo "Service running with pid: $PID"
           else


### PR DESCRIPTION
Sometimes "ps $PID | egrep "^$PID" doesn't works; check this:

  PID TTY      STAT   TIME COMMAND
 7245 ?        Ss     0:00 jsvc-itsm -home 

There's a blank space before "7245"; I changed to "ps -p $PID" and it's works for me.
